### PR TITLE
feat : access Token 만료시 error 필드 부합되는 필드메세지로 변경

### DIFF
--- a/api/src/main/java/com/tht/api/app/config/security/TokenProvider.java
+++ b/api/src/main/java/com/tht/api/app/config/security/TokenProvider.java
@@ -66,19 +66,19 @@ public class TokenProvider {
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             LogWriteUtils.logInfo(String.format("exception : %s, message : 잘못된 JWT 서명입니다.", e.getClass().getName()));
-            throw new TokenNotValidateException("잘못된 JWT 서명입니다.", e);
+            throw TokenNotValidateException.InvalidSecuritySign(e);
 
         } catch (ExpiredJwtException e) {
             LogWriteUtils.logInfo(String.format("exception : %s, message : 만료된 JWT 토큰입니다.", e.getClass().getName()));
-            throw new TokenNotValidateException("만료된 JWT 토큰입니다.", e);
+            throw TokenNotValidateException.ExpiredToken(e);
 
         } catch (UnsupportedJwtException e) {
             LogWriteUtils.logInfo(String.format("exception : %s, message : 지원되지 않는 JWT 토큰입니다.", e.getClass().getName()));
-            throw new TokenNotValidateException("지원되지 않는 JWT 토큰입니다.", e);
+            throw TokenNotValidateException.UnsupportedJwt(e);
 
         } catch (IllegalArgumentException e) {
             LogWriteUtils.logInfo(String.format("exception : %s, message : JWT 토큰이 잘못되었습니다.", e.getClass().getName()));
-            throw new TokenNotValidateException("JWT 토큰이 잘못되었습니다.", e);
+            throw TokenNotValidateException.IllegalArgumentJwt(e);
         }
     }
 

--- a/api/src/main/java/com/tht/api/app/config/security/filter/ExceptionHandlerFilter.java
+++ b/api/src/main/java/com/tht/api/app/config/security/filter/ExceptionHandlerFilter.java
@@ -26,14 +26,15 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     }
 
     public void setErrorResponse(HttpStatus status, HttpServletRequest request,
-        HttpServletResponse response, Throwable ex) throws IOException {
+        HttpServletResponse response, TokenNotValidateException ex) throws IOException {
 
         response.setStatus(status.value());
         response.setContentType("application/json; charset=UTF-8");
 
         response.getWriter().write(
             ErrorResponse.of(
-                    HttpStatus.UNAUTHORIZED,
+                    ex.getStatusValue(),
+                    ex.getReasonParse(),
                     ex.getMessage(),
                     request
                 )

--- a/api/src/main/java/com/tht/api/exception/custom/TokenNotValidateException.java
+++ b/api/src/main/java/com/tht/api/exception/custom/TokenNotValidateException.java
@@ -1,14 +1,46 @@
 package com.tht.api.exception.custom;
 
 import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
+@Getter
 public class TokenNotValidateException extends JwtException {
 
-    public TokenNotValidateException(String message) {
-        super(message);
+    private HttpStatus status;
+    private String reasonParse;
+
+    public TokenNotValidateException(String message, Throwable cause, HttpStatus status) {
+        super(message, cause);
+        this.status = status;
+        this.reasonParse = status.getReasonPhrase();
     }
 
-    public TokenNotValidateException(String message, Throwable cause) {
+    public TokenNotValidateException(String message, Throwable cause, HttpStatus status,
+        String reasonParse) {
         super(message, cause);
+        this.status = status;
+        this.reasonParse = reasonParse;
     }
+
+    public static TokenNotValidateException InvalidSecuritySign(final Throwable cause) {
+        return new TokenNotValidateException("잘못된 JWT 서명입니다.", cause, HttpStatus.UNAUTHORIZED);
+    }
+
+    public static TokenNotValidateException UnsupportedJwt(final Throwable cause) {
+        return new TokenNotValidateException("지원되지 않는 JWT 토큰입니다.", cause, HttpStatus.UNAUTHORIZED);
+    }
+
+    public static TokenNotValidateException IllegalArgumentJwt(final Throwable cause) {
+        return new TokenNotValidateException("JWT 토큰이 잘못되었습니다.", cause, HttpStatus.UNAUTHORIZED);
+    }
+
+    public static TokenNotValidateException ExpiredToken(final Throwable cause) {
+        return new TokenNotValidateException("만료된 JWT 토큰입니다.", cause, HttpStatus.UNAUTHORIZED, "access_token_expired");
+    }
+
+    public int getStatusValue() {
+        return status.value();
+    }
+
 }


### PR DESCRIPTION
//accessToken 만료
```
{
    "timestamp": "2023-12-01 10:41:18",
    "status": 401,
    "error": "access_token_expired",
    "message": "만료된 JWT 토큰입니다.",
    "path": "/user"
}
```


// 잘못된 accesssToken 
```
{
    "timestamp": "2023-12-01 13:59:48",
    "status": 401,
    "error": "Unauthorized",
    "message": "잘못된 JWT 서명입니다.",
    "path": "/user"
}
```